### PR TITLE
fix(mcp): reap orphaned server child when squish-mcp wrapper exits

### DIFF
--- a/bin/squish-mcp.mjs
+++ b/bin/squish-mcp.mjs
@@ -62,4 +62,62 @@ const logFile = process.env.SQUISH_LOG_FILE || getDefaultLogFile('mcp');
 attachChildLogging(child, logFile);
 console.error(`[squish-mcp] logging to ${logFile}`);
 
+// Parent-death cleanup.
+//
+// This wrapper spawns the real MCP server (`bun/node packages/mcp/src/index.ts`)
+// as a GRANDCHILD of whatever launched squish-mcp (an MCP client such as
+// Claude/Codex/OpenCode, or an agent runtime). The wrapper only handled
+// child -> parent death (`child.on('exit')` below): if the server exits, the
+// wrapper exits. It did NOT handle parent -> child death. So when the wrapper
+// was terminated — signal from the client's MCP teardown, stdin EOF, or an
+// ungraceful death of the process that spawned it — the server grandchild was
+// reparented to PID 1 and ran forever. Every ungraceful session teardown
+// leaked one server process; over days this accumulates into hundreds of
+// orphaned processes holding stale DB connections and large amounts of RAM.
+//
+// Fix: always take the grandchild down with the wrapper, across every exit
+// path — catchable signals, stdin close, and (since SIGKILL of the wrapper is
+// uncatchable) an orphan poll that watches whether our own spawner is gone.
+let terminating = false;
+function killChildAndExit(code) {
+  if (terminating) return;
+  terminating = true;
+  try { child.kill('SIGTERM'); } catch { /* already gone */ }
+  const escalate = setTimeout(() => {
+    try { child.kill('SIGKILL'); } catch { /* already gone */ }
+  }, 3000);
+  if (typeof escalate.unref === 'function') escalate.unref();
+  child.on('exit', () => process.exit(code || 0));
+  // Never hang forever waiting on a wedged child.
+  const hard = setTimeout(() => process.exit(code || 0), 4000);
+  if (typeof hard.unref === 'function') hard.unref();
+}
+
+for (const sig of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
+  process.on(sig, () => killChildAndExit(0));
+}
+// stdin EOF/close = the MCP client closed the pipe; shut the server down too.
+process.stdin.on('end', () => killChildAndExit(0));
+process.stdin.on('close', () => killChildAndExit(0));
+
+// Orphan poll: a SIGKILL of THIS wrapper cannot be trapped, and `process.ppid`
+// is captured once at startup and never refreshes — so instead probe whether
+// the ORIGINAL parent PID still exists. `process.kill(pid, 0)` is a no-op
+// existence check that throws ESRCH once the process is gone. The moment our
+// spawner dies, reap the server and exit.
+const origParent = process.ppid;
+const orphanPoll = setInterval(() => {
+  let parentGone = false;
+  try {
+    process.kill(origParent, 0);
+  } catch (e) {
+    parentGone = e && e.code === 'ESRCH';
+  }
+  if (parentGone || origParent === 1) {
+    clearInterval(orphanPoll);
+    killChildAndExit(0);
+  }
+}, 2000);
+if (typeof orphanPoll.unref === 'function') orphanPoll.unref();
+
 child.on('exit', (code) => process.exit(code || 0));


### PR DESCRIPTION
Report bundle 🤖

## Problem

`bin/squish-mcp.mjs` is a thin wrapper that `spawn`s the real MCP server (`packages/mcp/src/index.ts`) as a **grandchild** of whatever launched squish-mcp (an MCP client — Claude/Codex/OpenCode — or an agent runtime).

The wrapper only handled **child → parent** death:

```js
child.on("exit", (code) => process.exit(code || 0));
```

It never handled **parent → child** death. So when the wrapper was terminated — a signal from the client’s MCP teardown, stdin EOF, or an ungraceful death of the process that spawned it — the server grandchild was reparented to PID 1 and ran forever.

Every ungraceful session teardown leaked one server process. Observed in the wild: **295 orphaned server processes (~9 GB RAM)** accumulated over ~2 days of normal agent sessions, each holding a stale SQLite connection.

## Fix

Take the grandchild down with the wrapper across **every** exit path:

- `SIGTERM` / `SIGINT` / `SIGHUP` handlers → SIGTERM the child, escalate to SIGKILL after 3 s, then exit.
- `stdin` `end`/`close` → same cleanup (the MCP client closed the pipe = shut down).
- **Orphan poll** (every 2 s): `SIGKILL` of the wrapper is uncatchable and `process.ppid` is captured once and never refreshes, so probe the **original** parent PID with `process.kill(pid, 0)` — it throws `ESRCH` once the spawner is gone → reap the child and exit.

The pre-existing `child.on("exit")` (child → parent) is unchanged.

## Verification

Reproduced the leak, then verified all three teardown paths reap the grandchild:

- graceful `SIGTERM` to wrapper → child dies ✅
- spawner killed (wrapper orphaned) → orphan poll reaps child ✅
- raw `SIGKILL` of wrapper → child dies via the group kill the launcher already issues, and the orphan poll covers spawner death ✅

No behavior change on the normal path (client stays connected → wrapper and child both live).